### PR TITLE
generate-stars was called with too many args

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ Examples: [vikeri.github.io/om-semantic](http://vikeri.github.io/om-semantic/)
 ## Available components
 
 - Dropdown `dropdown.cljs`
+- Rating `rating.cljs`
 
 ## TODO
 
 - Make dropdown tabbable, and to be able to select with up/down keys
+- Give rating widget the ability to set 0 stars via clicking
+- Allow rating widget to use other icons, not just stars
 
 ## Add it as Leiningen dependency
 

--- a/src/om_semantic/rating.cljs
+++ b/src/om_semantic/rating.cljs
@@ -32,7 +32,7 @@
                         "ui rating disabled")
             rating (:rating data)
             max-rating (:max-rating data)
-            stars (generate-stars data rating max-rating)]
+            stars (generate-stars data)]
         (apply dom/div
                #js {:className className
                     :data-rating (:rating data)


### PR DESCRIPTION
generate-stars is now called with the correct number of arguments.
